### PR TITLE
Add level select screen

### DIFF
--- a/js/Game.js
+++ b/js/Game.js
@@ -6,6 +6,7 @@ import Input from "./Input.js";
 import Tiles from "./Tiles.js";
 import StartScreen from "./StartScreen.js";
 import PauseMenu from "./PauseMenu.js";
+import LevelSelect from "./LevelSelect.js";
 
 class Game {
     static instance;
@@ -189,6 +190,12 @@ class Game {
     startScreen() {
         this.playing = false;
         new StartScreen(this);
+        document.documentElement.style.setProperty("--ui-visible", 0);
+    }
+
+    levelSelectScreen() {
+        this.playing = false;
+        new LevelSelect(this);
         document.documentElement.style.setProperty("--ui-visible", 0);
     }
 

--- a/js/LevelSelect.js
+++ b/js/LevelSelect.js
@@ -1,0 +1,90 @@
+export default class LevelSelect {
+    constructor(game) {
+        this.game = game;
+        this.page = 0;
+        this.levelsPerPage = 9;
+        this.totalPages = Math.ceil(this.game.levels.levels.length / this.levelsPerPage);
+        this.buttonSize = 40;
+        this.spacing = 8;
+        this.startX = Math.floor((192 - (this.buttonSize * 3 + this.spacing * 2)) / 2);
+        this.startY = 40;
+
+        document.addEventListener("click", (event) => {
+            const rect = this.game.canvas.getBoundingClientRect();
+            const x = (192 / (rect.right - rect.left)) * (event.x - rect.left);
+            const y = (192 / (rect.right - rect.left)) * (event.y - rect.top);
+
+            // back button
+            if (x > 4 && y > 4 && x < 36 && y < 20) {
+                this.game.startScreen();
+                return;
+            }
+
+            // left / right page buttons
+            if (x < 20 && y > 120 && y < 136) {
+                this.page = (this.page - 1 + this.totalPages) % this.totalPages;
+                return;
+            }
+            if (x > 172 && y > 120 && y < 136) {
+                this.page = (this.page + 1) % this.totalPages;
+                return;
+            }
+
+            // level buttons
+            const col = Math.floor((x - this.startX) / (this.buttonSize + this.spacing));
+            const row = Math.floor((y - this.startY) / (this.buttonSize + this.spacing));
+            if (col >= 0 && col < 3 && row >= 0 && row < 3) {
+                const bx = this.startX + col * (this.buttonSize + this.spacing);
+                const by = this.startY + row * (this.buttonSize + this.spacing);
+                if (
+                    x > bx &&
+                    y > by &&
+                    x < bx + this.buttonSize &&
+                    y < by + this.buttonSize
+                ) {
+                    const index = this.page * this.levelsPerPage + row * 3 + col;
+                    if (index < this.game.levels.levels.length) {
+                        this.game.start(index);
+                    }
+                }
+            }
+        });
+
+        requestAnimationFrame(() => this.update());
+    }
+
+    update() {
+        const ctx = this.game.ctx;
+        ctx.fillStyle = "#0f0f1d";
+        ctx.fillRect(0, 0, 192, 256);
+
+        ctx.fillStyle = "#e8ce85";
+        ctx.font = "12px sans-serif";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+
+        // back button
+        ctx.fillText("Back", 20, 12);
+
+        // page indicators
+        ctx.fillText("<", 10, 128);
+        ctx.fillText(">", 182, 128);
+        ctx.fillText(`${this.page + 1}/${this.totalPages}`, 96, 20);
+
+        for (let i = 0; i < this.levelsPerPage; i++) {
+            const levelIndex = this.page * this.levelsPerPage + i;
+            if (levelIndex >= this.game.levels.levels.length) break;
+            const col = i % 3;
+            const row = Math.floor(i / 3);
+            const x = this.startX + col * (this.buttonSize + this.spacing);
+            const y = this.startY + row * (this.buttonSize + this.spacing);
+
+            ctx.strokeStyle = "#e8ce85";
+            ctx.strokeRect(x, y, this.buttonSize, this.buttonSize);
+            ctx.fillText(levelIndex + 1, x + this.buttonSize / 2, y + this.buttonSize / 2);
+        }
+
+        this.game.lastFrame = Date.now();
+        requestAnimationFrame(() => this.update());
+    }
+}

--- a/js/StartScreen.js
+++ b/js/StartScreen.js
@@ -68,7 +68,9 @@ export default class StartScreen {
                     x < 154 + this.buttonPadding &&
                     y < 184 + this.buttonPadding
                 ) {
-                    this.currentButton = 2;
+                    if (this.currentButton == 2) {
+                        this.game.levelSelectScreen();
+                    } else this.currentButton = 2;
                 }
             }
         });
@@ -96,6 +98,11 @@ export default class StartScreen {
             }
             if (this.game.input.keysPressed.space && this.currentButton == 1) {
                 this.timers.end = 0;
+            }
+            if (this.game.input.keysPressed.space && this.currentButton == 2) {
+                this.game.levelSelectScreen();
+                this.game.input.keysPressed.space = false;
+                return;
             }
             if (this.game.input.keysPressed.w) {
                 this.currentButton--;


### PR DESCRIPTION
## Summary
- add a new `LevelSelect` screen
- allow starting the level select from StartScreen
- include support for multiple pages
- update `Game` to support the new screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853e8024fa0832490515a450e286431